### PR TITLE
Fixed 'Access Denied' when user selects emoticon from palette

### DIFF
--- a/Client/src/main/ContainerCode.js
+++ b/Client/src/main/ContainerCode.js
@@ -226,7 +226,7 @@ function ChooseEmoticons ()
 					event.cancelBubble = true;
 					external.globals( 'cfg' ).Item( 'emoticonviewall' ) = ! ( external.globals( 'cfg' ).Item( 'emoticonviewall' ).toString() == 'true' );
 					Popup.hide();
-					window.parent.document.getElementById( 'btn-emoticons' ).click();
+					document.getElementById( 'btn-emoticons' ).click();
 				}
 			);
 			with ( Expand.style )

--- a/Client/src/main/ContainerCode.js
+++ b/Client/src/main/ContainerCode.js
@@ -262,8 +262,8 @@ function ChooseEmoticons ()
 				external.windows( 'MainWindow' ).Do( 'dial_emoticon_list', null );
 				Popup.hide();
 				Popup.document.body.innerHTML = '';
-				if ( ! window.parent.document.getElementById( 'send-text' ).disabled )
-					window.parent.document.getElementById( 'send-text' ).focus();
+				if ( ! document.getElementById( 'send-text' ).disabled )
+					document.getElementById( 'send-text' ).focus();
 			}
 		);
 		with ( Browse.style )
@@ -296,9 +296,9 @@ function ChooseEmoticons ()
 			function ( event )
 			{
 				if ( event.srcElement.tagName == 'DIV' )
-					window.parent.document.getElementById( 'send-text' ).value += event.srcElement.title;
-				if ( ! window.parent.document.getElementById( 'send-text' ).disabled )
-					window.parent.document.getElementById( 'send-text' ).focus();
+					document.getElementById( 'send-text' ).value += event.srcElement.title;
+				if ( ! document.getElementById( 'send-text' ).disabled )
+					document.getElementById( 'send-text' ).focus();
 				Popup.hide();
 				Popup.document.body.innerHTML = '';
 			}


### PR DESCRIPTION
When user select an emoticon from the palette, the function
ChoseEmoticons() try to getn an window.parent element, causing an
'Access Denied' error (Cross domain policy)

window.parent in this scenario is wrong, since the palette is in the
same document, so you can just use 'document' without any side-effects.
